### PR TITLE
Improve chunk unicode performance

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -33,3 +33,7 @@ it('should split emojis to 1 even if asked for 2', () => {
 it('should split emojis correctly w/ useByteLength option', () => {
   expect(fastChunkString('😀😃😄😁', {size: 2, unicodeAware: true})).toEqual(['😀😃', '😄😁']);
 });
+
+it('should split emojis correctly w/ useByteLength option for odd chunk length', () => {
+  expect(fastChunkString('😀😃😄', {size: 2, unicodeAware: true})).toEqual(['😀😃', '😄']);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,9 @@ function getChunksUnicode(str: string, size: number): string[] {
   let i = 0;
   let o = 0;
 
+  const runeChars = runes(str);
   for (; i < numChunks; ++i, o += size) {
-    chunks[i] = runes.substr(str, o, size);
+    chunks[i] = runeChars.slice(o, o + size).join('');
   }
 
   return chunks;


### PR DESCRIPTION
Hey 👋 
I've accidentally found this module, and you had a nice setup for benchmarking, so I tried to improve performance a bit :)
The unicode chunking should get much faster because of not doing runes split on every loop iteration: https://github.com/dotcypress/runes/blob/develop/index.js#L145-L146